### PR TITLE
Make sure player data file exists before reading it.

### DIFF
--- a/src/core/Tracker.java
+++ b/src/core/Tracker.java
@@ -34,7 +34,11 @@ public class Tracker {
 		for(String s: entries) {
 			File playerFolder = new File(index.getPath(), s);
 			String data = "";
-			String localData = Utils.readJsonToString(playerFolder + "/data.json");
+			String fileLocation = playerFolder + "/data.json";
+			// make sure player data exists before attempting to read from it
+			File tmpFile = new File(fileLocation);
+			if(tmpFile.exists()) {	
+				String localData = Utils.readJsonToString(fileLocation);
 			String discordid = Stats.getDiscordId(localData);
 			
 			

--- a/src/core/Tracker.java
+++ b/src/core/Tracker.java
@@ -39,32 +39,34 @@ public class Tracker {
 			File tmpFile = new File(fileLocation);
 			if(tmpFile.exists()) {	
 				String localData = Utils.readJsonToString(fileLocation);
-			String discordid = Stats.getDiscordId(localData);
-			
-			
-			String uuid = Stats.getUUID(localData);
-			int oldQ = 0;
-			int newQ = 0;
-			int oldF = 0;
-			int newF = 0;
-			
-			if(!Utils.isInsideTheServer(discordid)) Utils.unlinkMember(uuid);
-			if(!Utils.isOnline(discordid) && !forced) continue;
-			
-			data = Request.getPlayerStatsUUID(uuid);
-			if (data == null) continue;
-			if (API.getPlayer(data) == null) continue;
-			
-			oldQ = Stats.getQualificationToInt(localData);
-			newQ = API.getQualificationToInt(data);
-			oldF = Stats.getFinalsToInt(localData);
-			newF = API.getFinalsToInt(data);
-			
-			if (newQ > oldQ) MessageSender.pbMessage(data, discordid, uuid, 'q');
-			if (newF > oldF) MessageSender.pbMessage(data, discordid, uuid, 'f');
-			Utils.updateFile(data, localData, uuid, "linked player");
-			Utils.updateFile(data, localData, uuid, "leaderboard");
-			delay(750);
+				String discordid = Stats.getDiscordId(localData);
+
+
+				String uuid = Stats.getUUID(localData);
+				int oldQ = 0;
+				int newQ = 0;
+				int oldF = 0;
+				int newF = 0;
+				
+				if(!Utils.isInsideTheServer(discordid)) Utils.unlinkMember(uuid);
+				if(!Utils.isOnline(discordid) && !forced) continue;
+				
+				data = Request.getPlayerStatsUUID(uuid);
+				if (data == null) continue;
+				if (API.getPlayer(data) == null) continue;
+
+				oldQ = Stats.getQualificationToInt(localData);
+				newQ = API.getQualificationToInt(data);
+				oldF = Stats.getFinalsToInt(localData);
+				newF = API.getFinalsToInt(data);
+
+				if (newQ > oldQ) MessageSender.pbMessage(data, discordid, uuid, 'q');
+				if (newF > oldF) MessageSender.pbMessage(data, discordid, uuid, 'f');
+				Utils.updateFile(data, localData, uuid, "linked player");
+				Utils.updateFile(data, localData, uuid, "leaderboard");
+				// Wait 500ms before making more api requests to avoid rate limit
+				delay(500);
+			}
 		}
 	}
 	

--- a/src/core/Tracker.java
+++ b/src/core/Tracker.java
@@ -35,38 +35,38 @@ public class Tracker {
 			File playerFolder = new File(index.getPath(), s);
 			String data = "";
 			String fileLocation = playerFolder + "/data.json";
+
 			// make sure player data exists before attempting to read from it
 			File tmpFile = new File(fileLocation);
-			if(tmpFile.exists()) {	
-				String localData = Utils.readJsonToString(fileLocation);
-				String discordid = Stats.getDiscordId(localData);
+			if(tmpFile.exists()) continue;
 
+			String localData = Utils.readJsonToString(fileLocation);
+			String discordid = Stats.getDiscordId(localData);
 
-				String uuid = Stats.getUUID(localData);
-				int oldQ = 0;
-				int newQ = 0;
-				int oldF = 0;
-				int newF = 0;
-				
-				if(!Utils.isInsideTheServer(discordid)) Utils.unlinkMember(uuid);
-				if(!Utils.isOnline(discordid) && !forced) continue;
-				
-				data = Request.getPlayerStatsUUID(uuid);
-				if (data == null) continue;
-				if (API.getPlayer(data) == null) continue;
+			String uuid = Stats.getUUID(localData);
+			int oldQ = 0;
+			int newQ = 0;
+			int oldF = 0;
+			int newF = 0;
+			
+			if(!Utils.isInsideTheServer(discordid)) Utils.unlinkMember(uuid);
+			if(!Utils.isOnline(discordid) && !forced) continue;
 
-				oldQ = Stats.getQualificationToInt(localData);
-				newQ = API.getQualificationToInt(data);
-				oldF = Stats.getFinalsToInt(localData);
-				newF = API.getFinalsToInt(data);
+			data = Request.getPlayerStatsUUID(uuid);
+			if (data == null) continue;
+			if (API.getPlayer(data) == null) continue;
 
-				if (newQ > oldQ) MessageSender.pbMessage(data, discordid, uuid, 'q');
-				if (newF > oldF) MessageSender.pbMessage(data, discordid, uuid, 'f');
-				Utils.updateFile(data, localData, uuid, "linked player");
-				Utils.updateFile(data, localData, uuid, "leaderboard");
-				// Wait 500ms before making more api requests to avoid rate limit
-				delay(500);
-			}
+			oldQ = Stats.getQualificationToInt(localData);
+			newQ = API.getQualificationToInt(data);
+			oldF = Stats.getFinalsToInt(localData);
+			newF = API.getFinalsToInt(data);
+
+			if (newQ > oldQ) MessageSender.pbMessage(data, discordid, uuid, 'q');
+			if (newF > oldF) MessageSender.pbMessage(data, discordid, uuid, 'f');
+			Utils.updateFile(data, localData, uuid, "linked player");
+			Utils.updateFile(data, localData, uuid, "leaderboard");
+			// Wait 500ms before making more api requests to avoid rate limit
+			delay(500);
 		}
 	}
 	


### PR DESCRIPTION
It appears that its possible for a file to be removed while the tracker thread is looping through the list of players. This PR adds a simple check to make sure the file exists just prior to reading it.