### PR TITLE
Make sure file exists before attempting to unlink. Closes #18

### DIFF
--- a/src/commands/CommandUnlink.java
+++ b/src/commands/CommandUnlink.java
@@ -1,5 +1,7 @@
 package commands;
 
+import java.io.File;
+
 import core.Command;
 import core.CommandExecutable;
 import core.Request;
@@ -15,13 +17,15 @@ public class CommandUnlink extends CommandExecutable {
 	@Override
 	protected boolean execute() {
 		if (command.getArgs().length == 0) return (badUsage(this));
-		
 		String uuid = GeneralUtils.getUUIDfromDiscord(command.getArgs()[0]);
 		if (uuid == null) uuid = Request.getPlayerUUID(command.getArgs()[0]);
 		if (uuid == null) return (unlinkError(this));
-		
+
+		// Avoid NPE if file does not exist
+		if(!new File("linked player/" + uuid).exists()) return (unlinkError(this));
+
 		GeneralUtils.unlinkMember(uuid);
-		
+
 		MessageSender.messageJSON(command, "unlink");
 		return (true);
 	}


### PR DESCRIPTION
This just makes sure the file exists beforehand.